### PR TITLE
Accept title input and use to populate title front-matter

### DIFF
--- a/lib/views/new-article-view.coffee
+++ b/lib/views/new-article-view.coffee
@@ -39,18 +39,21 @@ module.exports =
       articleDirectory = atom.config.get('middleman-article-creator.articleDirectory')
       path.join(atom.project.getPaths()[0], articleDirectory)
 
+    parameterizeString: (str) ->
+      str.trim().toLowerCase().replace(/[^a-zA-Z0-9 -]/, "").replace(/\s/g, "-")
+
     createArticle: (name) ->
       dt = new Date();
       formattedDate = dt.toFormat('YYYY-MM-DD');
 
-      pathToCreate = path.join(@articlesDir(), "#{formattedDate}-#{name}.md")
+      pathToCreate = path.join(@articlesDir(), "#{formattedDate}-#{@parameterizeString(name)}.md")
 
       touch pathToCreate
 
       atom.workspace.open(pathToCreate).then ->
         contents = """
         ---
-        title:
+        title: #{name}
         date: #{formattedDate}
         tags:
         ---


### PR DESCRIPTION
This change updates the title prompt so it accepts a full post title, eg. "My Post" instead of the parameterized version, eg. "my-post". The code then generates the file name from the title and then uses the title to populate the post front-matter, thus saving some typing.

I'm not sure if you're open to pull requests, but I made this change on my personal fork and figured I'd submit this in case you're interested.